### PR TITLE
[YSI-17] 애플 로그인 구현 및 Auth API 연동

### DIFF
--- a/Yakssok/Project.swift
+++ b/Yakssok/Project.swift
@@ -28,7 +28,7 @@ let project = Project(
                         "Pretendard-Bold.otf"
                     ],
                     "KAKAO_NATIVE_APP_KEY": "$(KAKAO_NATIVE_APP_KEY)",
-                    "API_BASE_URL": "$(API_BASE_URL)",
+                    "API_BASE_URL": "https://yakssok.site",
                     "CFBundleURLTypes": [
                         [
                             "CFBundleURLName": "kakao",

--- a/Yakssok/Project.swift
+++ b/Yakssok/Project.swift
@@ -33,6 +33,10 @@ let project = Project(
                         [
                             "CFBundleURLName": "kakao",
                             "CFBundleURLSchemes": ["kakao$(KAKAO_NATIVE_APP_KEY)"]
+                        ],
+                        [
+                            "CFBundleURLName": "apple",
+                            "CFBundleURLSchemes": ["$(PRODUCT_BUNDLE_IDENTIFIER)"]
                         ]
                     ],
                     "LSApplicationQueriesSchemes": [
@@ -43,6 +47,7 @@ let project = Project(
             ),
             sources: ["Yakssok/Sources/**"],
             resources: ["Yakssok/Resources/**"],
+            entitlements: "Yakssok/Yakssok.entitlements",
             dependencies: [
                 .external(name: "ComposableArchitecture"),
                 .external(name: "Dependencies"),

--- a/Yakssok/Yakssok/Sources/Features/Auth/AuthFeature.swift
+++ b/Yakssok/Yakssok/Sources/Features/Auth/AuthFeature.swift
@@ -25,20 +25,25 @@ struct AuthFeature: Reducer {
     var body: some ReducerOf<Self> {
         Reduce { state, action in
             switch action {
-            case .login(.isCompleted(let isExistingUser, let authorizationCode)):
+            case .login(.isCompleted(let isExistingUser, let authorizationCode, let oauthType)):
                 state.login = nil
                 if isExistingUser {
                     return .send(.authenticationCompleted)
                 } else {
                     var onboardingState = OnboardingFeature.State()
                     onboardingState.authorizationCode = authorizationCode ?? ""
+                    onboardingState.oauthType = oauthType ?? "kakao"
                     state.onboarding = onboardingState
                     return .none
                 }
 
-            case .onboarding(.isCompleted(let nickname, let authorizationCode)):
+            case .onboarding(.isCompleted(let nickname, let authorizationCode, let oauthType)):
                 state.onboarding = nil
-                state.loading = LoadingFeature.State(nickname: nickname, authorizationCode: authorizationCode)
+                state.loading = LoadingFeature.State(
+                    nickname: nickname,
+                    authorizationCode: authorizationCode,
+                    oauthType: oauthType
+                )
                 return .none
 
             case .loading(.registrationCompleted):

--- a/Yakssok/Yakssok/Sources/Features/Auth/Onboarding/OnboardingFeature.swift
+++ b/Yakssok/Yakssok/Sources/Features/Auth/Onboarding/OnboardingFeature.swift
@@ -11,6 +11,8 @@ struct OnboardingFeature: Reducer {
     struct State: Equatable {
         var nickname: String = ""
         var authorizationCode: String = ""
+        var oauthType: String = ""
+        var identityToken: String? // Apple 로그인용
 
         var isButtonEnabled: Bool {
             !nickname.trimmingCharacters(in: .whitespaces).isEmpty && nickname.count <= 5
@@ -21,7 +23,7 @@ struct OnboardingFeature: Reducer {
         case onAppear
         case nicknameChanged(String)
         case startButtonTapped
-        case isCompleted(nickname: String, authorizationCode: String)
+        case isCompleted(nickname: String, authorizationCode: String, oauthType: String)
         case backToLogin
     }
 
@@ -39,8 +41,12 @@ struct OnboardingFeature: Reducer {
 
             case .startButtonTapped:
                 guard state.isButtonEnabled else { return .none }
-                return .send(.isCompleted(nickname: state.nickname, authorizationCode: state.authorizationCode))
-
+                return .send(.isCompleted(
+                    nickname: state.nickname,
+                    authorizationCode: state.authorizationCode,
+                    oauthType: state.oauthType
+                ))
+                
             case .backToLogin:
                 return .none
 

--- a/Yakssok/Yakssok/Sources/Network/Clients/AppleAuthClient.swift
+++ b/Yakssok/Yakssok/Sources/Network/Clients/AppleAuthClient.swift
@@ -1,0 +1,117 @@
+//
+//  AppleAuthClient.swift
+//  Yakssok
+//
+//  Created by 김사랑 on 7/26/25.
+//
+
+import ComposableArchitecture
+import Dependencies
+import AuthenticationServices
+import Foundation
+
+struct AppleAuthClient {
+    var login: @Sendable () async throws -> AppleLoginResult
+    var logout: @Sendable () async throws -> Void
+    var isLoggedIn: @Sendable () -> Bool
+}
+
+struct AppleLoginResult: Equatable {
+    let identityToken: String
+}
+
+extension AppleAuthClient: DependencyKey {
+    static let liveValue = Self(
+        login: {
+            return try await AppleSignInManager.shared.signIn()
+        },
+        logout: {
+            return
+        },
+        isLoggedIn: {
+            return TokenManager.shared.isLoggedIn
+        }
+    )
+}
+
+extension DependencyValues {
+    var appleAuthClient: AppleAuthClient {
+        get { self[AppleAuthClient.self] }
+        set { self[AppleAuthClient.self] = newValue }
+    }
+}
+
+@MainActor
+class AppleSignInManager: NSObject, ObservableObject {
+    static let shared = AppleSignInManager()
+
+    private var currentContinuation: CheckedContinuation<AppleLoginResult, Error>?
+
+    private override init() {
+        super.init()
+    }
+
+    func signIn() async throws -> AppleLoginResult {
+        return try await withCheckedThrowingContinuation { continuation in
+            guard currentContinuation == nil else {
+                continuation.resume(throwing: NSError(domain: "AppleLogin", code: -1, userInfo: [NSLocalizedDescriptionKey: "중복 요청"]))
+                return
+            }
+
+            currentContinuation = continuation
+
+            let provider = ASAuthorizationAppleIDProvider()
+            let request = provider.createRequest()
+            request.requestedScopes = [.fullName, .email]
+
+            let controller = ASAuthorizationController(authorizationRequests: [request])
+            controller.delegate = self
+            controller.presentationContextProvider = self
+            controller.performRequests()
+        }
+    }
+
+    private func completeContinuation(with result: Result<AppleLoginResult, Error>) {
+        guard let continuation = currentContinuation else { return }
+        currentContinuation = nil
+
+        switch result {
+        case .success(let loginResult):
+            continuation.resume(returning: loginResult)
+        case .failure(let error):
+            continuation.resume(throwing: error)
+        }
+    }
+}
+
+extension AppleSignInManager: ASAuthorizationControllerDelegate {
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
+        guard let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential else {
+            completeContinuation(with: .failure(NSError(domain: "AppleLogin", code: -1, userInfo: [NSLocalizedDescriptionKey: "유효하지 않은 인증 정보"])))
+            return
+        }
+
+        guard let identityTokenData = appleIDCredential.identityToken,
+              let identityToken = String(data: identityTokenData, encoding: .utf8) else {
+            completeContinuation(with: .failure(NSError(domain: "AppleLogin", code: -2, userInfo: [NSLocalizedDescriptionKey: "Identity Token을 받을 수 없음"])))
+            return
+        }
+
+        let result = AppleLoginResult(identityToken: identityToken)
+        completeContinuation(with: .success(result))
+    }
+
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
+        completeContinuation(with: .failure(error))
+    }
+}
+
+extension AppleSignInManager: ASAuthorizationControllerPresentationContextProviding {
+    func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+        guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+              let window = windowScene.windows.first else {
+            fatalError("Unable to find window")
+        }
+        return window
+    }
+}

--- a/Yakssok/Yakssok/Sources/Network/Clients/KakaoAuthClient.swift
+++ b/Yakssok/Yakssok/Sources/Network/Clients/KakaoAuthClient.swift
@@ -12,9 +12,13 @@ import KakaoSDKUser
 import Foundation
 
 struct KakaoAuthClient {
-    var login: @Sendable () async throws -> String
+    var login: @Sendable () async throws -> KakaoLoginResult
     var logout: @Sendable () async throws -> Void
     var isLoggedIn: @Sendable () -> Bool
+}
+
+struct KakaoLoginResult: Equatable {
+    let authorizationCode: String
 }
 
 extension KakaoAuthClient: DependencyKey {
@@ -29,7 +33,8 @@ extension KakaoAuthClient: DependencyKey {
                             if let error = error {
                                 continuation.resume(throwing: error)
                             } else if let token = result {
-                                continuation.resume(returning: token.accessToken)
+                                let kakaoResult = KakaoLoginResult(authorizationCode: token.accessToken)
+                                continuation.resume(returning: kakaoResult)
                             } else {
                                 continuation.resume(throwing: NSError(domain: "KakaoLogin", code: -1, userInfo: [NSLocalizedDescriptionKey: "알 수 없는 오류"]))
                             }
@@ -40,7 +45,8 @@ extension KakaoAuthClient: DependencyKey {
                             if let error = error {
                                 continuation.resume(throwing: error)
                             } else if let token = result {
-                                continuation.resume(returning: token.accessToken)
+                                let kakaoResult = KakaoLoginResult(authorizationCode: token.accessToken)
+                                continuation.resume(returning: kakaoResult)
                             } else {
                                 continuation.resume(throwing: NSError(domain: "KakaoLogin", code: -1, userInfo: [NSLocalizedDescriptionKey: "알 수 없는 오류"]))
                             }
@@ -49,7 +55,7 @@ extension KakaoAuthClient: DependencyKey {
                 }
             }
         },
-        
+
         logout: {
             return try await withCheckedThrowingContinuation { continuation in
                 UserApi.shared.logout { error in
@@ -61,7 +67,7 @@ extension KakaoAuthClient: DependencyKey {
                 }
             }
         },
-        
+
         isLoggedIn: {
             return AuthApi.hasToken()
         }

--- a/Yakssok/Yakssok/Yakssok.entitlements
+++ b/Yakssok/Yakssok/Yakssok.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.developer.applesignin</key>
+    <array>
+        <string>Default</string>
+    </array>
+</dict>
+</plist>


### PR DESCRIPTION
## 📝 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
- [x] Apple Sign In 기능 구현 (ASAuthorizationController 활용)
- [x] Apple OAuth identityToken 기반 서버 연동
- [x] Apple 로그인 → 온보딩 → 회원가입 플로우 완성
- [x] KakaoAuthClient와 AppleAuthClient 인터페이스 통일
- [x] LoginResult 구조체를 내부 타입으로 정리
- [x] Swift Concurrency async/await 패턴 적용
- [x] Project.swift에 Apple URL scheme 및 entitlements 설정


## 📸 시연 영상
<!-- (+스크린샷)이 있다면 적어주세요. 없으면 지워주세요-->
https://github.com/user-attachments/assets/295f2807-2d50-4ae0-97bc-684acf73c902


## 💻 추후 진행할 사항
<!-- 추후에 진행할 사항들에 대해 적어주세요. -->
- 홈 화면 API 연동


## 🔗 Reference
<!-- 참고한 자료를 작성해주세요 -->
[Apple Sign In 공식 문서](https://developer.apple.com/documentation/authenticationservices/implementing_user_authentication_with_sign_in_with_apple)
[ASAuthorizationController 가이드](https://developer.apple.com/documentation/authenticationservices/asauthorizationcontroller)


## ☑️ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
