### PR TITLE
[YSI-53] 내 프로필, 팔로잉 메이트 프로필 불러오기 API 연동

### DIFF
--- a/Yakssok/Yakssok/Sources/Network/Clients/UserClient.swift
+++ b/Yakssok/Yakssok/Sources/Network/Clients/UserClient.swift
@@ -9,14 +9,27 @@ import ComposableArchitecture
 
 struct UserClient {
     var loadUsers: () async throws -> [User]
+    var loadUserProfile: () async throws -> UserProfileResponse
 }
 
 extension UserClient: DependencyKey {
     static let liveValue = Self(
         loadUsers: {
-            // TODO: 실제 API 구현
-            // 테스트: 3가지 상태 중 하나 선택해서 테스트: onlyMe, sample, many
-            return MockUserData.users(for: .sample)
+            return []
+        },
+
+        loadUserProfile: {
+            let response: UserProfileResponse = try await APIClient.shared.request(
+                endpoint: .getUserProfile,
+                method: .GET,
+                body: Optional<String>.none
+            )
+
+            if response.code != 0 {
+                throw APIError.serverError(response.code)
+            }
+
+            return response
         }
     )
 }

--- a/Yakssok/Yakssok/Sources/Network/Clients/UserClient.swift
+++ b/Yakssok/Yakssok/Sources/Network/Clients/UserClient.swift
@@ -15,7 +15,22 @@ struct UserClient {
 extension UserClient: DependencyKey {
     static let liveValue = Self(
         loadUsers: {
-            return []
+            do {
+                let response: FollowingListResponse = try await APIClient.shared.request(
+                    endpoint: .getFollowingList,
+                    method: .GET,
+                    body: Optional<String>.none
+                )
+
+                if response.code != 0 {
+                    throw APIError.serverError(response.code)
+                }
+
+                return response.body.followingInfoResponses.map { $0.toUser() }
+            } catch {
+
+                return []
+            }
         },
 
         loadUserProfile: {

--- a/Yakssok/Yakssok/Sources/Network/Core/NetworkCore.swift
+++ b/Yakssok/Yakssok/Sources/Network/Core/NetworkCore.swift
@@ -31,8 +31,7 @@ enum APIEndpoints {
     case refreshToken
 
     // MARK: - User Endpoints
-    case userProfile
-    case updateUserProfile
+    case getUserProfile
 
     // MARK: - Medicine Endpoints
     case medicineData
@@ -63,10 +62,8 @@ enum APIEndpoints {
             return "/api/auth/reissue"
 
         // User
-        case .userProfile:
-            return "/api/user/profile"
-        case .updateUserProfile:
-            return "/api/user/profile"
+        case .getUserProfile:
+            return "/api/users/me"
 
         // Medicine
         case .medicineData:

--- a/Yakssok/Yakssok/Sources/Network/Core/NetworkCore.swift
+++ b/Yakssok/Yakssok/Sources/Network/Core/NetworkCore.swift
@@ -33,6 +33,9 @@ enum APIEndpoints {
     // MARK: - User Endpoints
     case getUserProfile
 
+    // MARK: - Friend Endpoints
+    case getFollowingList
+
     // MARK: - Medicine Endpoints
     case medicineData
     case medicineDataForDate(Date)
@@ -64,6 +67,10 @@ enum APIEndpoints {
         // User
         case .getUserProfile:
             return "/api/users/me"
+
+        // Friend
+        case .getFollowingList:
+            return "/api/friends/followings"
 
         // Medicine
         case .medicineData:

--- a/Yakssok/Yakssok/Sources/Network/Models/UserModels.swift
+++ b/Yakssok/Yakssok/Sources/Network/Models/UserModels.swift
@@ -20,3 +20,32 @@ struct UserProfileBody: Codable, Equatable {
     let medicationCount: Int
     let followingCount: Int
 }
+
+// MARK: - GET /api/friends/followings Response
+struct FollowingListResponse: Codable, Equatable {
+    let code: Int
+    let message: String
+    let body: FollowingListBody
+}
+
+struct FollowingListBody: Codable, Equatable {
+    let followingInfoResponses: [FollowingInfo]
+}
+
+struct FollowingInfo: Codable, Equatable {
+    let userId: Int
+    let relationName: String
+    let profileImageUrl: String?
+    let nickName: String
+}
+
+// MARK: - API Response to UI Model Conversion
+extension FollowingInfo {
+    func toUser() -> User {
+        return User(
+            id: String(userId),
+            name: relationName,
+            profileImage: profileImageUrl
+        )
+    }
+}

--- a/Yakssok/Yakssok/Sources/Network/Models/UserModels.swift
+++ b/Yakssok/Yakssok/Sources/Network/Models/UserModels.swift
@@ -1,0 +1,22 @@
+//
+//  UserModels.swift
+//  Yakssok
+//
+//  Created by 김사랑 on 7/27/25.
+//
+
+import Foundation
+
+// MARK: - GET /api/users/me Response
+struct UserProfileResponse: Codable, Equatable {
+    let code: Int
+    let message: String
+    let body: UserProfileBody
+}
+
+struct UserProfileBody: Codable, Equatable {
+    let nickname: String
+    let profileImageUrl: String?
+    let medicationCount: Int
+    let followingCount: Int
+}


### PR DESCRIPTION
## 📝 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
- [x] 사용자 프로필 조회 API 연동 (GET /api/users/me)
- [x] 팔로잉 메이트 목록 조회 API 연동 (GET /api/friends/followings)
- [x] 홈/캘린더 화면에서 실제 프로필 이미지 표시 (이름은 "나"로 고정)
- [x] MateSelection에 실제 팔로잉 메이트들 표시 (relationName 사용)


## 📸 스크린샷
<!-- (+스크린샷)이 있다면 적어주세요. 없으면 지워주세요-->
|:---:|
|<img width="250" src="https://github.com/user-attachments/assets/08877306-618e-4789-be93-e2e966867c04">|


## 💻 추후 진행할 사항
<!-- 추후에 진행할 사항들에 대해 적어주세요. -->
- 내 메이트 복약 불러오기 


## ☑️ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
