### PR TITLE
[YSI-50] 내 메이트 복약 불러오기 API 연동

### DIFF
--- a/Yakssok/Yakssok/Sources/Domain/Entities/User.swift
+++ b/Yakssok/Yakssok/Sources/Domain/Entities/User.swift
@@ -7,6 +7,20 @@
 
 struct User: Equatable {
     let id: String
+    let friendId: Int?
     let name: String
     let profileImage: String?
+
+    var isCurrentUser: Bool {
+        return name == "나"
+    }
+
+    static func defaultCurrentUser() -> User {
+        return User(
+            id: "current_user",
+            friendId: nil,
+            name: "나",
+            profileImage: nil
+        )
+    }
 }

--- a/Yakssok/Yakssok/Sources/Features/Home/FullCalendar/FullCalendarFeature.swift
+++ b/Yakssok/Yakssok/Sources/Features/Home/FullCalendar/FullCalendarFeature.swift
@@ -171,11 +171,7 @@ struct FullCalendarFeature: Reducer {
                 }
 
             case .userProfileLoaded(let response):
-                let currentUser = User(
-                    id: "current_user_id",
-                    name: "나",
-                    profileImage: response.body.profileImageUrl
-                )
+                let currentUser = response.toCurrentUser()
 
                 return .merge(
                     .send(.medicineList(.updateCurrentUser(currentUser))),
@@ -183,11 +179,7 @@ struct FullCalendarFeature: Reducer {
                 )
 
             case .userProfileLoadFailed:
-                let defaultUser = User(
-                    id: "current_user_id",
-                    name: "나",
-                    profileImage: nil
-                )
+                let defaultUser = User.defaultCurrentUser()
 
                 return .merge(
                     .send(.medicineList(.updateCurrentUser(defaultUser))),
@@ -237,7 +229,10 @@ struct FullCalendarFeature: Reducer {
                 return .none
 
             case .userSelection(.delegate(.userSelectionChanged(let user))):
-                return .send(.medicineList(.updateSelectedUser(user)))
+                return .merge(
+                    .send(.medicineList(.updateSelectedUser(user))),
+                    .send(.loadMonthlyData)
+                )
 
             case .userSelection(.userSelected):
                 return .none

--- a/Yakssok/Yakssok/Sources/Features/Home/HomeFeature.swift
+++ b/Yakssok/Yakssok/Sources/Features/Home/HomeFeature.swift
@@ -124,26 +124,16 @@ struct HomeFeature: Reducer {
             }
 
         case .userProfileLoaded(let response):
-            let currentUser = User(
-                id: "current_user_id",
-                name: "나",
-                profileImage: response.body.profileImageUrl
-            )
+            let currentUser = response.toCurrentUser()
             state.currentUser = currentUser
-
             return .merge(
                 .send(.medicineList(.updateCurrentUser(currentUser))),
                 .send(.userSelection(.updateCurrentUser(currentUser)))
             )
 
         case .userProfileLoadFailed(let error):
-            let defaultUser = User(
-                id: "current_user_id",
-                name: "나",
-                profileImage: nil
-            )
+            let defaultUser = User.defaultCurrentUser()
             state.currentUser = defaultUser
-
             return .send(.medicineList(.updateCurrentUser(defaultUser)))
 
         case .notificationTapped:

--- a/Yakssok/Yakssok/Sources/Features/MyPage/MyMates/MyMatesFeature.swift
+++ b/Yakssok/Yakssok/Sources/Features/MyPage/MyMates/MyMatesFeature.swift
@@ -81,31 +81,31 @@ struct MyMatesFeature: Reducer {
     // Mock 데이터 생성 함수들을 static으로 변경
     static func createMockUsers() -> [User] {
         return [
-            User(
-                id: "user1",
-                name: "나",
-                profileImage: "https://randomuser.me/api/portraits/med/women/1.jpg"
-            ),
-            User(
-                id: "user2",
-                name: "나",
-                profileImage: "https://randomuser.me/api/portraits/med/men/1.jpg"
-            )
+//            User(
+//                id: "user1",
+//                name: "나",
+//                profileImage: "https://randomuser.me/api/portraits/med/women/1.jpg"
+//            ),
+//            User(
+//                id: "user2",
+//                name: "나",
+//                profileImage: "https://randomuser.me/api/portraits/med/men/1.jpg"
+//            )
         ]
     }
 
     static func createMockFollowers() -> [User] {
         return [
-            User(
-                id: "follower1",
-                name: "나",
-                profileImage: "https://randomuser.me/api/portraits/med/women/2.jpg"
-            ),
-            User(
-                id: "follower2",
-                name: "나",
-                profileImage: "https://randomuser.me/api/portraits/med/men/2.jpg"
-            )
+//            User(
+//                id: "follower1",
+//                name: "나",
+//                profileImage: "https://randomuser.me/api/portraits/med/women/2.jpg"
+//            ),
+//            User(
+//                id: "follower2",
+//                name: "나",
+//                profileImage: "https://randomuser.me/api/portraits/med/men/2.jpg"
+//            )
         ]
     }
 }

--- a/Yakssok/Yakssok/Sources/Mock/MockUserData.swift
+++ b/Yakssok/Yakssok/Sources/Mock/MockUserData.swift
@@ -5,6 +5,7 @@
 //  Created by 김사랑 on 7/8/25.
 //
 
+/*
 import Foundation
 
 #if DEBUG
@@ -55,3 +56,4 @@ struct MockUserData {
     ]
 }
 #endif
+*/

--- a/Yakssok/Yakssok/Sources/Network/Core/NetworkCore.swift
+++ b/Yakssok/Yakssok/Sources/Network/Core/NetworkCore.swift
@@ -45,6 +45,10 @@ enum APIEndpoints {
     case getMedicationSchedules(Date, Date)
     case takeMedication(Int)
 
+    // MARK: - Friend Medicine Endpoints
+    case getFriendMedicationSchedulesToday(Int)
+    case getFriendMedicationSchedules(Int, Date, Date)
+
     // MARK: - Notification Endpoints
     case notifications
 
@@ -93,6 +97,16 @@ enum APIEndpoints {
             return "/api/medication-schedules?startDate=\(start)&endDate=\(end)"
         case .takeMedication(let scheduleId):
             return "/api/medication-schedules/\(scheduleId)/take"
+
+        // Friend Medicine
+        case .getFriendMedicationSchedulesToday(let friendId):
+            return "/api/medication-schedules/friends/\(friendId)/today"
+        case .getFriendMedicationSchedules(let friendId, let startDate, let endDate):
+            let formatter = DateFormatter()
+            formatter.dateFormat = "yyyy-MM-dd"
+            let start = formatter.string(from: startDate)
+            let end = formatter.string(from: endDate)
+            return "/api/medication-schedules/friends/\(friendId)?startDate=\(start)&endDate=\(end)"
 
         // Notification
         case .notifications:

--- a/Yakssok/Yakssok/Sources/Network/Models/UserModels.swift
+++ b/Yakssok/Yakssok/Sources/Network/Models/UserModels.swift
@@ -44,8 +44,20 @@ extension FollowingInfo {
     func toUser() -> User {
         return User(
             id: String(userId),
+            friendId: userId,
             name: relationName,
             profileImage: profileImageUrl
+        )
+    }
+}
+
+extension UserProfileResponse {
+    func toCurrentUser() -> User {
+        return User(
+            id: "current_user",
+            friendId: nil,
+            name: "나",
+            profileImage: body.profileImageUrl
         )
     }
 }


### PR DESCRIPTION
## 📝 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
- [x] 지인 복약 스케줄 조회 (오늘) API 연동 (GET /api/medication-schedules/friends/{friendId}/today)
- [x] 지인 복약 스케줄 조회 (기간) API 연동 (GET /api/medication-schedules/friends/{friendId})
- [x] User 모델에 friendId 필드 및 isCurrentUser 속성 추가하여 친구/본인 구분
- [x] MedicineClient에 친구 복약 관련 메서드 구현 (loadFriendTodaySchedules, loadFriendSchedulesForDateRange 등)
- [x] 홈화면 및 캘린더에서 친구 선택 시 해당 친구의 복약 정보 조회 기능 구현
- [x] FullCalendar에서 친구 선택 시 월간 복약 상태에 맞는 캘린더 아이콘 동적 변경


## 📸 변경 전/후 스크린샷
https://github.com/user-attachments/assets/88ecb875-b6b4-4c0d-930b-30bccdabbc79


## 💻 추후 진행할 사항
<!-- 추후에 진행할 사항들에 대해 적어주세요. -->
- 메이트에게 잔소리/응원 보내기 API 연동


## ☑️ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
