### PR TITLE
[YSI-52] 잔소리/칭찬 API 연동

### DIFF
--- a/Yakssok/Yakssok/Sources/Domain/Entities/MateCard.swift
+++ b/Yakssok/Yakssok/Sources/Domain/Entities/MateCard.swift
@@ -13,6 +13,8 @@ struct MateCard: Identifiable, Equatable {
     let relationship: String
     let profileImage: String?
     let status: MateStatus
+    let todayMedicines: [Medicine]
+    let completedMedicines: [Medicine]
 }
 
 enum MateStatus: Equatable {

--- a/Yakssok/Yakssok/Sources/Features/Home/HomeFeature.swift
+++ b/Yakssok/Yakssok/Sources/Features/Home/HomeFeature.swift
@@ -290,11 +290,11 @@ struct HomeFeature: Reducer {
             return .none
         }
 
-        let medicineCount = getMedicineCount(for: card, messageType: messageType)
-        let mockData = MockMedicineData.medicineData(for: .hasMedicines)
         let medicines = messageType == .nagging ?
-        mockData.todayMedicines :
-        mockData.completedMedicines
+        card.todayMedicines :   // 못 먹은 약
+        card.completedMedicines // 먹은 약
+
+        let medicineCount = medicines.count
 
         state.messageModal = MessageModalFeature.State(
             targetUser: targetUser,
@@ -305,16 +305,5 @@ struct HomeFeature: Reducer {
             medicines: medicines
         )
         return .none
-    }
-
-    private func getMedicineCount(for card: MateCard, messageType: MessageType) -> Int {
-        switch (card.status, messageType) {
-        case (.missedMedicine(let count), .nagging):
-            return count
-        case (.completed, .encouragement):
-            return 2
-        default:
-            return 0
-        }
     }
 }

--- a/Yakssok/Yakssok/Sources/Features/Home/HomeFeature.swift
+++ b/Yakssok/Yakssok/Sources/Features/Home/HomeFeature.swift
@@ -43,7 +43,7 @@ struct HomeFeature: Reducer {
         case weeklyCalendar(WeeklyCalendarFeature.Action)
         case medicineList(MedicineListFeature.Action)
         case messageModal(MessageModalFeature.Action)
-        case showMessageModal(targetUser: String, messageType: MessageType)
+        case showMessageModal(targetUser: String, targetUserId: Int, messageType: MessageType)
         case dismissMessageModal
         case reminderModal(ReminderModalFeature.Action)
         case showReminderModal
@@ -155,8 +155,8 @@ struct HomeFeature: Reducer {
         case .showReminderModal:
             return handleShowMissedMedicineModal(&state)
 
-        case .showMessageModal(let targetUser, let messageType):
-            return handleShowMessageModal(&state, targetUser: targetUser, messageType: messageType)
+        case .showMessageModal(let targetUser, let targetUserId, let messageType):
+            return handleShowMessageModal(&state, targetUser: targetUser, targetUserId: targetUserId, messageType: messageType)
 
         case .dismissMessageModal:
             state.messageModal = nil
@@ -220,8 +220,8 @@ struct HomeFeature: Reducer {
         case .userSelection(.delegate(.addUserRequested)):
             return .send(.showMateRegistration)
 
-        case .mateCards(.delegate(.showMessageModal(let targetUser, let messageType))):
-            return .send(.showMessageModal(targetUser: targetUser, messageType: messageType))
+        case .mateCards(.delegate(.showMessageModal(let targetUser, let targetUserId, let messageType))):
+            return .send(.showMessageModal(targetUser: targetUser, targetUserId: targetUserId, messageType: messageType))
 
         case .medicineList(.delegate(.addMedicineRequested)):
             return .send(.showAddRoutine)
@@ -231,7 +231,7 @@ struct HomeFeature: Reducer {
             state.reminderModal = nil
             return .none
 
-        case .messageModal(.closeButtonTapped), .messageModal(.sendButtonTapped):
+        case .messageModal(.closeButtonTapped), .messageModal(.sendingCompleted):
             state.messageModal = nil
             return .none
 
@@ -283,6 +283,7 @@ struct HomeFeature: Reducer {
     private func handleShowMessageModal(
         _ state: inout State,
         targetUser: String,
+        targetUserId: Int,
         messageType: MessageType
     ) -> Effect<Action> {
         guard let card = state.mateCards?.cards.first(where: { $0.userName == targetUser }) else {
@@ -297,6 +298,7 @@ struct HomeFeature: Reducer {
 
         state.messageModal = MessageModalFeature.State(
             targetUser: targetUser,
+            targetUserId: targetUserId,
             messageType: messageType,
             medicineCount: medicineCount,
             relationship: card.relationship,

--- a/Yakssok/Yakssok/Sources/Features/Home/HomeFeature.swift
+++ b/Yakssok/Yakssok/Sources/Features/Home/HomeFeature.swift
@@ -110,7 +110,8 @@ struct HomeFeature: Reducer {
         case .onResume:
             return .merge(
                 .send(.loadUserProfile),
-                .send(.medicineList(.loadInitialData))
+                .send(.medicineList(.loadInitialData)),
+                .send(.mateCards(.loadCards))
             )
 
         case .loadUserProfile:

--- a/Yakssok/Yakssok/Sources/Features/Home/MateCards/MateCardsFeature.swift
+++ b/Yakssok/Yakssok/Sources/Features/Home/MateCards/MateCardsFeature.swift
@@ -21,7 +21,7 @@ struct MateCardsFeature: Reducer {
         case delegate(Delegate)
 
         enum Delegate: Equatable {
-            case showMessageModal(targetUser: String, messageType: MessageType)
+            case showMessageModal(targetUser: String, targetUserId: Int, messageType: MessageType)
         }
     }
 
@@ -47,6 +47,10 @@ struct MateCardsFeature: Reducer {
                 guard let card = state.cards.first(where: { $0.id == cardId }) else {
                     return .none
                 }
+                
+                guard let userId = Int(cardId) else {
+                    return .none
+                }
 
                 let messageType: MessageType = {
                     switch card.status {
@@ -59,6 +63,7 @@ struct MateCardsFeature: Reducer {
 
                 return .send(.delegate(.showMessageModal(
                     targetUser: card.userName,
+                    targetUserId: userId,
                     messageType: messageType
                 )))
 

--- a/Yakssok/Yakssok/Sources/Features/Home/MateCards/MateCardsFeature.swift
+++ b/Yakssok/Yakssok/Sources/Features/Home/MateCards/MateCardsFeature.swift
@@ -10,8 +10,6 @@ import ComposableArchitecture
 struct MateCardsFeature: Reducer {
     struct State: Equatable {
         var cards: [MateCard] = []
-        var isLoading: Bool = false
-        var error: String?
     }
 
     @CasePathable
@@ -20,10 +18,8 @@ struct MateCardsFeature: Reducer {
         case cardTapped(id: String)
         case loadCards
         case cardsLoaded([MateCard])
-        case loadingFailed(String)
         case delegate(Delegate)
 
-        @CasePathable
         enum Delegate: Equatable {
             case showMessageModal(targetUser: String, messageType: MessageType)
         }
@@ -36,21 +32,22 @@ struct MateCardsFeature: Reducer {
             switch action {
             case .onAppear:
                 return .send(.loadCards)
+
             case .loadCards:
-                state.isLoading = true
-                state.error = nil
                 return .run { send in
                     do {
                         let cards = try await mateCardsClient.loadCards()
                         await send(.cardsLoaded(cards))
                     } catch {
-                        await send(.loadingFailed(error.localizedDescription))
+                        await send(.cardsLoaded([]))
                     }
                 }
+
             case .cardTapped(let cardId):
                 guard let card = state.cards.first(where: { $0.id == cardId }) else {
                     return .none
                 }
+
                 let messageType: MessageType = {
                     switch card.status {
                     case .missedMedicine:
@@ -59,19 +56,17 @@ struct MateCardsFeature: Reducer {
                         return .encouragement
                     }
                 }()
+
                 return .send(.delegate(.showMessageModal(
                     targetUser: card.userName,
                     messageType: messageType
                 )))
+
             case .cardsLoaded(let cards):
                 state.cards = cards
-                state.isLoading = false
                 return .none
-            case .loadingFailed(let error):
-                state.error = error
-                state.isLoading = false
-                return .none
-            case .delegate(_):
+
+            case .delegate:
                 return .none
             }
         }

--- a/Yakssok/Yakssok/Sources/Mock/MockMateCardData.swift
+++ b/Yakssok/Yakssok/Sources/Mock/MockMateCardData.swift
@@ -5,6 +5,7 @@
 //  Created by 김사랑 on 7/8/25.
 //
 
+/*
 import Foundation
 
 struct MockMateCardData {
@@ -103,3 +104,4 @@ struct MockMateCardData {
         )
     ]
 }
+*/

--- a/Yakssok/Yakssok/Sources/Network/Clients/AppleAuthClient.swift
+++ b/Yakssok/Yakssok/Sources/Network/Clients/AppleAuthClient.swift
@@ -6,7 +6,6 @@
 //
 
 import ComposableArchitecture
-import Dependencies
 import AuthenticationServices
 import Foundation
 

--- a/Yakssok/Yakssok/Sources/Network/Clients/AuthAPIClient.swift
+++ b/Yakssok/Yakssok/Sources/Network/Clients/AuthAPIClient.swift
@@ -6,7 +6,6 @@
 //
 
 import ComposableArchitecture
-import Dependencies
 import Foundation
 
 struct AuthAPIClient {

--- a/Yakssok/Yakssok/Sources/Network/Clients/FeedbackAPIClient.swift
+++ b/Yakssok/Yakssok/Sources/Network/Clients/FeedbackAPIClient.swift
@@ -1,0 +1,37 @@
+//
+//  FeedbackAPIClient.swift
+//  Yakssok
+//
+//  Created by 김사랑 on 8/3/25.
+//
+
+import ComposableArchitecture
+import Dependencies
+import Foundation
+
+struct FeedbackAPIClient {
+    var sendFeedback: @Sendable (FeedbackRequest) async throws -> Void
+}
+
+extension FeedbackAPIClient: DependencyKey {
+    static let liveValue = Self(
+        sendFeedback: { request in
+            let response: FeedbackResponse = try await APIClient.shared.request(
+                endpoint: .sendFeedback,
+                method: .POST,
+                body: request
+            )
+
+            if response.code != 0 {
+                throw APIError.serverError(response.code)
+            }
+        }
+    )
+}
+
+extension DependencyValues {
+    var feedbackAPIClient: FeedbackAPIClient {
+        get { self[FeedbackAPIClient.self] }
+        set { self[FeedbackAPIClient.self] = newValue }
+    }
+}

--- a/Yakssok/Yakssok/Sources/Network/Clients/KakaoAuthClient.swift
+++ b/Yakssok/Yakssok/Sources/Network/Clients/KakaoAuthClient.swift
@@ -6,7 +6,6 @@
 //
 
 import ComposableArchitecture
-import Dependencies
 import KakaoSDKAuth
 import KakaoSDKUser
 import Foundation

--- a/Yakssok/Yakssok/Sources/Network/Clients/MateCardsClient.swift
+++ b/Yakssok/Yakssok/Sources/Network/Clients/MateCardsClient.swift
@@ -46,7 +46,9 @@ extension MateCardsClient: DependencyKey {
                             userName: friend.nickName,
                             relationship: friend.relationName,
                             profileImage: friend.profileImageUrl,
-                            status: status
+                            status: status,
+                            todayMedicines: medicineData.todayMedicines,
+                            completedMedicines: medicineData.completedMedicines
                         )
                         mateCards.append(card)
                     }

--- a/Yakssok/Yakssok/Sources/Network/Clients/MateCardsClient.swift
+++ b/Yakssok/Yakssok/Sources/Network/Clients/MateCardsClient.swift
@@ -42,7 +42,7 @@ extension MateCardsClient: DependencyKey {
 
                     if let status = getMateStatus(medicineData: medicineData) {
                         let card = MateCard(
-                            id: "mate_\(friend.userId)",
+                            id: String(friend.userId),
                             userName: friend.nickName,
                             relationship: friend.relationName,
                             profileImage: friend.profileImageUrl,

--- a/Yakssok/Yakssok/Sources/Network/Clients/MateCardsClient.swift
+++ b/Yakssok/Yakssok/Sources/Network/Clients/MateCardsClient.swift
@@ -6,6 +6,7 @@
 //
 
 import ComposableArchitecture
+import Foundation
 
 struct MateCardsClient {
     var loadCards: () async throws -> [MateCard]
@@ -14,9 +15,47 @@ struct MateCardsClient {
 extension MateCardsClient: DependencyKey {
     static let liveValue = Self(
         loadCards: {
-            // TODO: 실제 API 구현
-            // 테스트: 3가지 상태 중 하나 선택해서 테스트: empty, sample, many
-            return MockMateCardData.cards(for: .sample)
+            let followingResponse: FollowingListResponse = try await APIClient.shared.request(
+                endpoint: .getFollowingList,
+                method: .GET,
+                body: Optional<String>.none
+            )
+
+            guard followingResponse.code == 0 else {
+                throw APIError.serverError(followingResponse.code)
+            }
+
+            var mateCards: [MateCard] = []
+            let today = Date()
+
+            for friend in followingResponse.body.followingInfoResponses {
+                do {
+                    let scheduleResponse: MedicationScheduleResponse = try await APIClient.shared.request(
+                        endpoint: .getFriendMedicationSchedulesToday(friend.userId),
+                        method: .GET,
+                        body: Optional<String>.none
+                    )
+
+                    guard scheduleResponse.code == 0 else { continue }
+
+                    let medicineData = scheduleResponse.toMedicineDataResponse()
+
+                    if let status = getMateStatus(medicineData: medicineData) {
+                        let card = MateCard(
+                            id: "mate_\(friend.userId)",
+                            userName: friend.nickName,
+                            relationship: friend.relationName,
+                            profileImage: friend.profileImageUrl,
+                            status: status
+                        )
+                        mateCards.append(card)
+                    }
+                } catch {
+                    continue
+                }
+            }
+
+            return mateCards
         }
     )
 }
@@ -26,4 +65,23 @@ extension DependencyValues {
         get { self[MateCardsClient.self] }
         set { self[MateCardsClient.self] = newValue }
     }
+}
+
+private func getMateStatus(medicineData: MedicineDataResponse) -> MateStatus? {
+    let totalMedicines = medicineData.todayMedicines.count + medicineData.completedMedicines.count
+
+    // 약이 없으면 카드 안 뜸
+    guard totalMedicines > 0 else { return nil }
+
+    // 모든 약을 다 먹었으면 칭찬
+    if medicineData.todayMedicines.isEmpty && medicineData.completedMedicines.count > 0 {
+        return .completed
+    }
+
+    // 안 먹은 약이 있으면 잔소리
+    if medicineData.todayMedicines.count > 0 {
+        return .missedMedicine(count: medicineData.todayMedicines.count)
+    }
+
+    return nil
 }

--- a/Yakssok/Yakssok/Sources/Network/Clients/MedicineClient.swift
+++ b/Yakssok/Yakssok/Sources/Network/Clients/MedicineClient.swift
@@ -6,7 +6,6 @@
 //
 
 import ComposableArchitecture
-import Dependencies
 import Foundation
 
 struct MedicineClient {

--- a/Yakssok/Yakssok/Sources/Network/Core/NetworkCore.swift
+++ b/Yakssok/Yakssok/Sources/Network/Core/NetworkCore.swift
@@ -49,6 +49,9 @@ enum APIEndpoints {
     case getFriendMedicationSchedulesToday(Int)
     case getFriendMedicationSchedules(Int, Date, Date)
 
+    // MARK: - Feedback Endpoint
+    case sendFeedback
+
     // MARK: - Notification Endpoints
     case notifications
 
@@ -107,6 +110,10 @@ enum APIEndpoints {
             let start = formatter.string(from: startDate)
             let end = formatter.string(from: endDate)
             return "/api/medication-schedules/friends/\(friendId)?startDate=\(start)&endDate=\(end)"
+
+        // Feedback
+        case .sendFeedback:
+            return "/api/feedbacks"
 
         // Notification
         case .notifications:

--- a/Yakssok/Yakssok/Sources/Network/Models/FeedbackModels.swift
+++ b/Yakssok/Yakssok/Sources/Network/Models/FeedbackModels.swift
@@ -1,0 +1,42 @@
+//
+//  FeedbackModels.swift
+//  Yakssok
+//
+//  Created by 김사랑 on 8/3/25.
+//
+
+import Foundation
+
+// MARK: - Request
+struct FeedbackRequest: Codable {
+    let receiverId: Int
+    let message: String
+    let type: String // praise or nag
+}
+
+// MARK: - Response
+struct FeedbackResponse: Codable {
+    let code: Int
+    let message: String
+    let body: EmptyBody?
+}
+
+extension FeedbackRequest {
+    /// 잔소리 피드백 생성
+    static func nag(receiverId: Int, message: String) -> FeedbackRequest {
+        return FeedbackRequest(
+            receiverId: receiverId,
+            message: message,
+            type: "nag"
+        )
+    }
+
+    /// 칭찬 피드백 생성
+    static func praise(receiverId: Int, message: String) -> FeedbackRequest {
+        return FeedbackRequest(
+            receiverId: receiverId,
+            message: message,
+            type: "praise"
+        )
+    }
+}


### PR DESCRIPTION
## 📝 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
- [x] 메이트 카드 API 연동 (친구별 오늘 약 복용 상태 조회)
- [x] 피드백 전송 API 연동 (POST /api/feedbacks)
- [x] 메이트 카드에 실제 약 데이터 포함 (못 먹은 약/먹은 약)
- [x] 잔소리/칭찬 타입별 메시지 전송


## 📸 변경 전/후 스크린샷
<!-- (+스크린샷)이 있다면 적어주세요. 없으면 지워주세요-->
|작업 전|작업 후|
|:---:|:---:|
|<img width="250" src="https://github.com/user-attachments/assets/b7ce54e4-c96c-4f14-9ef1-ed5cdf0d89b5">|<img width="250" src="https://github.com/user-attachments/assets/9bb1192b-4ad7-44c7-ae94-94abdd2a396a">|


## 💻 추후 진행할 사항
<!-- 추후에 진행할 사항들에 대해 적어주세요. -->
- 메이트 추가 API 연동


## ☑️ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
