### PR TITLE
[YSI-56] 내 초대코드 불러오기, 메이트 추가 API 연동

### DIFF
--- a/Yakssok/Yakssok/Sources/Features/AddMate/MateRegistration/MateRegistrationView.swift
+++ b/Yakssok/Yakssok/Sources/Features/AddMate/MateRegistration/MateRegistrationView.swift
@@ -53,8 +53,10 @@ struct MateRegistrationView: View {
                             .background(YKColor.Neutral.grey50)
                             .cornerRadius(Layout.myCodeCardCornerRadius, corners: [.topLeft, .topRight])
                             .ignoresSafeArea(.container, edges: .bottom)
+                            .ignoresSafeArea(.keyboard, edges: .bottom)
                         }
                     }
+                    .ignoresSafeArea(.keyboard, edges: .top)
                     .sheet(isPresented: viewStore.binding(
                         get: \.showShareSheet,
                         send: { _ in .dismissShareSheet }
@@ -65,8 +67,8 @@ struct MateRegistrationView: View {
                         .presentationDetents([.medium])
                     }
                     .onAppear {
-                            viewStore.send(.onAppear)
-                        }
+                        viewStore.send(.onAppear)
+                    }
                 }
 
                 // 성공/에러 메시지 오버레이
@@ -92,7 +94,15 @@ struct MateRegistrationView: View {
                     MateRelationshipView(store: relationshipStore)
                 }
             }
+            .onTapGesture {
+                // Swift 6에서 권장하는 키보드 내리기 방식
+                if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+                   let window = windowScene.windows.first {
+                    window.endEditing(true)
+                }
+            }
         }
+        .ignoresSafeArea(.keyboard, edges: .top) // NavigationView 전체 상단 고정
     }
 }
 

--- a/Yakssok/Yakssok/Sources/Features/AddMate/MateRegistration/MateRegistrationView.swift
+++ b/Yakssok/Yakssok/Sources/Features/AddMate/MateRegistration/MateRegistrationView.swift
@@ -60,12 +60,13 @@ struct MateRegistrationView: View {
                         send: { _ in .dismissShareSheet }
                     )) {
                         ShareSheet(items: [
-                            "약쏙 메이트가 되어 복약을 함께 관리해요!",
-                            "내 코드: \(viewStore.myCode)",
-                            URL(string: "https://yakssok.app/invite/\(viewStore.myCode)")!
+                            "\(viewStore.currentUserName)님이 함께 약 챙기자고 해요. 가끔 잊어버릴 수도 있으니까,\n서로 약 잘 먹고 있는지 확인하며 챙기는 건 어때요?\n필요할 땐 잔소리도 살짝😉\n\(viewStore.currentUserName)님의 코드: \(viewStore.myCode)\n👇 여기로 들어오면 같이 챙길 수 있어요"
                         ])
                         .presentationDetents([.medium])
                     }
+                    .onAppear {
+                            viewStore.send(.onAppear)
+                        }
                 }
 
                 // 성공/에러 메시지 오버레이

--- a/Yakssok/Yakssok/Sources/Features/Home/FullCalendar/FullCalendarFeature.swift
+++ b/Yakssok/Yakssok/Sources/Features/Home/FullCalendar/FullCalendarFeature.swift
@@ -209,7 +209,8 @@ struct FullCalendarFeature: Reducer {
                 return .none
 
             case .showMateRegistration:
-                state.mateRegistration = .init()
+                let userName = state.userSelection?.currentUser?.name ?? ""
+                state.mateRegistration = MateRegistrationFeature.State(currentUserName: userName)
                 return .none
 
             case .dismissMateRegistration:

--- a/Yakssok/Yakssok/Sources/Features/Home/HomeFeature.swift
+++ b/Yakssok/Yakssok/Sources/Features/Home/HomeFeature.swift
@@ -218,7 +218,10 @@ struct HomeFeature: Reducer {
 
         case .mateRegistration(.delegate(.mateAddingCompleted)):
             state.mateRegistration = nil
-            return .send(.userSelection(.loadUsers))
+            return .merge(
+                .send(.userSelection(.loadUsers)),
+                .send(.mateCards(.loadCards))
+            )
 
         case .userSelection(.delegate(.addUserRequested)):
             return .send(.showMateRegistration)

--- a/Yakssok/Yakssok/Sources/Features/Home/HomeFeature.swift
+++ b/Yakssok/Yakssok/Sources/Features/Home/HomeFeature.swift
@@ -11,6 +11,7 @@ import ComposableArchitecture
 struct HomeFeature: Reducer {
     struct State: Equatable {
         var currentUser: User?
+        var currentUserNickname: String?
         var selectedDate: Date = Date()
         var userSelection: MateSelectionFeature.State? = .init()
         var mateCards: MateCardsFeature.State? = .init()
@@ -127,6 +128,7 @@ struct HomeFeature: Reducer {
         case .userProfileLoaded(let response):
             let currentUser = response.toCurrentUser()
             state.currentUser = currentUser
+            state.currentUserNickname = response.body.nickname
             return .merge(
                 .send(.medicineList(.updateCurrentUser(currentUser))),
                 .send(.userSelection(.updateCurrentUser(currentUser)))
@@ -179,7 +181,8 @@ struct HomeFeature: Reducer {
             return .none
 
         case .showMateRegistration:
-            state.mateRegistration = .init()
+            let userName = state.currentUserNickname ?? ""
+            state.mateRegistration = .init(currentUserName: userName)
             return .none
 
         case .dismissMateRegistration:

--- a/Yakssok/Yakssok/Sources/Network/Clients/MateRegistrationClient.swift
+++ b/Yakssok/Yakssok/Sources/Network/Clients/MateRegistrationClient.swift
@@ -1,0 +1,69 @@
+//
+//  MateRegistrationClient.swift
+//  Yakssok
+//
+//  Created by 김사랑 on 8/3/25.
+//
+
+import ComposableArchitecture
+import Dependencies
+import Foundation
+
+struct MateRegistrationClient {
+    var getMyInviteCode: @Sendable () async throws -> String
+    var getUserByInviteCode: @Sendable (String) async throws -> UserByInviteCodeBody
+    var followFriend: @Sendable (String, String) async throws -> Void
+}
+
+extension MateRegistrationClient: DependencyKey {
+    static let liveValue = Self(
+        getMyInviteCode: {
+            let response: MyInviteCodeResponse = try await APIClient.shared.request(
+                endpoint: .getMyInviteCode,
+                method: .GET,
+                body: Optional<String>.none
+            )
+            guard response.code == 0 else {
+                throw APIError.serverError(response.code)
+            }
+            return response.body.inviteCode
+        },
+
+        getUserByInviteCode: { inviteCode in
+            let response: UserByInviteCodeResponse = try await APIClient.shared.request(
+                endpoint: .getUserByInviteCode(inviteCode),
+                method: .GET,
+                body: Optional<String>.none
+            )
+            guard response.code == 0 else {
+                if response.code == 404 {
+                    throw APIError.userNotFound
+                }
+                throw APIError.serverError(response.code)
+            }
+            return response.body
+        },
+
+        followFriend: { inviteCode, relationName in
+            let request = FollowFriendRequest(
+                inviteCode: inviteCode,
+                relationName: relationName
+            )
+            let response: FollowFriendResponse = try await APIClient.shared.request(
+                endpoint: .followFriend,
+                method: .POST,
+                body: request
+            )
+            guard response.code == 0 else {
+                throw APIError.serverError(response.code)
+            }
+        }
+    )
+}
+
+extension DependencyValues {
+    var mateRegistrationClient: MateRegistrationClient {
+        get { self[MateRegistrationClient.self] }
+        set { self[MateRegistrationClient.self] = newValue }
+    }
+}

--- a/Yakssok/Yakssok/Sources/Network/Core/NetworkCore.swift
+++ b/Yakssok/Yakssok/Sources/Network/Core/NetworkCore.swift
@@ -55,9 +55,10 @@ enum APIEndpoints {
     // MARK: - Notification Endpoints
     case notifications
 
-    // MARK: - Mate Endpoints
-    case mateCards
-    case registerMate
+    // MARK: - Mate Registration Endpoints
+    case getMyInviteCode
+    case getUserByInviteCode(String)
+    case followFriend
 
     var path: String {
         switch self {
@@ -119,11 +120,13 @@ enum APIEndpoints {
         case .notifications:
             return "/api/notifications"
 
-        // Mate
-        case .mateCards:
-            return "/api/mate/cards"
-        case .registerMate:
-            return "/api/mate/register"
+        // Mate Registration
+        case .getMyInviteCode:
+            return "/api/users/invite-code"
+        case .getUserByInviteCode(let inviteCode):
+            return "/api/users?inviteCode=\(inviteCode)"
+        case .followFriend:
+            return "/api/friends"
         }
     }
 

--- a/Yakssok/Yakssok/Sources/Network/Models/MateRegistrationModels.swift
+++ b/Yakssok/Yakssok/Sources/Network/Models/MateRegistrationModels.swift
@@ -1,0 +1,43 @@
+//
+//  MateRegistrationModels.swift
+//  Yakssok
+//
+//  Created by 김사랑 on 8/3/25.
+//
+
+import Foundation
+
+// MARK: - 내 초대 코드 조회
+struct MyInviteCodeResponse: Codable {
+    let code: Int
+    let message: String
+    let body: MyInviteCodeBody
+}
+
+struct MyInviteCodeBody: Codable {
+    let inviteCode: String
+}
+
+// MARK: - 초대 코드로 사용자 조회
+struct UserByInviteCodeResponse: Codable {
+    let code: Int
+    let message: String
+    let body: UserByInviteCodeBody
+}
+
+struct UserByInviteCodeBody: Codable {
+    let nickname: String
+    let profileImageUrl: String?
+}
+
+// MARK: - 지인 팔로우 (메이트 추가)
+struct FollowFriendRequest: Codable {
+    let inviteCode: String
+    let relationName: String
+}
+
+struct FollowFriendResponse: Codable {
+    let code: Int
+    let message: String
+    let body: EmptyBody?
+}


### PR DESCRIPTION
## 📝 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
- [x] 내 초대 코드 조회 API 연동 (GET /api/users/invite-code)
- [x] 초대 코드로 사용자 조회 API 연동 (GET /api/users?inviteCode=xxx)
- [x] 메이트 팔로우 API 연동 (POST /api/friends)
- [x] 키보드 조정 UI 개선 (하단 버튼 고정, 배경 터치로 키보드 내리기)
- [x] 메이트 등록 화면에서 실제 사용자 닉네임 불러오기
- [x] 초대 메시지 수정


## 📸 시연 영상
<!-- (+스크린샷)이 있다면 적어주세요. 없으면 지워주세요-->
https://github.com/user-attachments/assets/d6bb0d66-e1f8-4ee0-be8e-370167b4b4b4


## 💻 추후 진행할 사항
<!-- 추후에 진행할 사항들에 대해 적어주세요. -->
- 알림 불러오기 API 연동


## ☑️ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
